### PR TITLE
theia compatibility and small messages fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "nuvolaris",
 	"icon": "media/nuv_market.png",
 	"description": "Nuvolaris extension for VS Code",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"publisher": "nuvolaris",
 	"repository": "https://github.com/nuvolaris/nuvolaris-vscode-extension",
 	"engines": {

--- a/publish.sh
+++ b/publish.sh
@@ -5,4 +5,4 @@ vsce package
 vsce publish
 
 VER="$(jq -r .version package.json)"
-gh release create v$VER -t v$VER nuvolaris-vscode-extension-${VER}.vsix
+gh release create v$VER -t v$VER nuvolaris-vscode-extension.vsix

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,14 @@ let context: vscode.ExtensionContext;
 
 export async function activate(ctx: vscode.ExtensionContext) {
 	try {
+
+		// Necessary for Theia compatibility of welcome screen. See https://github.com/eclipse-theia/theia/issues/9361
+		vscode.window.registerTreeDataProvider(
+			"command-palette",
+			new EmptyTreeDataProvider()
+		);
+		// 
+
 		context = ctx;
 		if (!isLoggedIn()) {
 			LoginPanel.render(handleLogin, context.extensionUri);
@@ -75,9 +83,24 @@ function launchTerminal(command: string): void {
 }
 
 function printError(error: any) {
-	return vscode.window.showErrorMessage("Error occurred", error.toString());
+	return vscode.window.showErrorMessage(error.toString());
 }
 function printInfo(info: string) {
-	return vscode.window.showInformationMessage("Info", info);
+	return vscode.window.showInformationMessage(info);
 
+}
+
+export function deactivate() {}
+
+// Necessary for Theia compatibility of welcome screen. See https://github.com/eclipse-theia/theia/issues/9361
+export class EmptyTreeDataProvider implements vscode.TreeDataProvider<any> {
+	constructor() {}
+
+	getTreeItem(element: any): vscode.TreeItem {
+		return {};
+	}
+
+	getChildren(element?: any): Thenable<any[]> {
+		return new Promise((resolve) => resolve([]));
+	}
 }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -18,13 +18,13 @@ function main() {
       .addEventListener("click", handleLoginSubmit);
 
     LoginPage.getUsername()
-      .addEventListener("keypress", validateLogin);
+      .addEventListener("input", validateLogin);
 
     LoginPage.getPassword()
-      .addEventListener("keypress", validateLogin);
-
+      .addEventListener("input", validateLogin)
+      
     LoginPage.getApiHost()
-      .addEventListener("keypress", validateLogin);
+      .addEventListener("input", validateLogin);
 
   } catch (error: any) {
     sendError(error);


### PR DESCRIPTION
The following changes have been made:

- Added a compatibility code to make the command palette work in Theia. (See issue https://github.com/eclipse-theia/theia/issues/9361)
- Fixed the appearance of info and error messages.
- Fixed a bug that required you to type inside the password input to trigger the form validation. That didn't give a good experience when copy - pasting a password. Updated to a proper "input" event listener.
- Changed versioning logic to allow Theia custom IDE to get the latest release of the extension.